### PR TITLE
[EO-3203] Always return the Jenkins instance reference to a label in NodeAction

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/NodeAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/NodeAction.java
@@ -34,23 +34,29 @@ import hudson.model.queue.SubTask;
 import java.util.List;
 
 /**
- * {@link Action} that restricts the job to a particular node 
+ * {@link Action} that restricts the job to a particular node
  * when a project is scheduled
  * Will cause a unique build for each different node if a job is already queued.
- * 
+ *
  * @author Chris Johnson
  */
 public class NodeAction extends InvisibleAction implements LabelAssignmentAction, Queue.QueueAction, BuildBadgeAction {
 	private final Label nodeLabel;
-	
+
 	public NodeAction(Label nodeLabel) {
 		this.nodeLabel = nodeLabel;
 	}
 
 	public Label getAssignedLabel(SubTask task) {
-		return nodeLabel;
+		if (nodeLabel != null) {
+			// Ensure that we are returning the canonical Label for this expression,
+			// according to the Jenkins instance.
+			return Label.get(nodeLabel.getName());
+		} else {
+			return nodeLabel;
+		}
 	}
-	
+
 	public boolean shouldSchedule(List<Action> actions) {
 		// see if there is already a matching action with same node
 		for (NodeAction other:Util.filter(actions, NodeAction.class)) {


### PR DESCRIPTION
### SUMMARY
* This PR is a quick fix for an issue in the upstream plugin.
* Internal ticket: [EO-3203](https://jira.dp.hbo.com/browse/EO-3203)  hadron-auto-reboot-node-v1 is not working as intended
* Related JIRA ticket: [JENKINS-57507](https://issues.jenkins-ci.org/browse/JENKINS-57507)

### DETAILS
When the parameterized trigger plugin triggers a build, it attaches a `NodeAction` which refers directly to a Label object.  This normally is totally fine, but in the case of a machine disconnect at the wrong moment, you can end up with a Label that becomes "orphaned" -- Jenkins periodically cleans up Labels that have no nodes connected, and will then _recreate_ a Label for the node when it reconnects.  In this case, the Label attached to the NodeAction is an orphaned object that will never see newly connected nodes.

The fix is to always return the canonical Label from the Jenkins instance, rather than returning our own potentially stale reference.

### TESTS
- No unit tests have been updated.
- Manual testing verified on `native-jenkins`.
- Example build: see https://native-jenkins.hadron.hbo.com/job/master-auto-reboot-node-v1/4/timings/.  To trigger the issue, I started a job on the target machine and killed the swarm client while it was running.  The job sat in the queue until the client reconnected (~1min), then immediately started on the reconnected node.