### PR TITLE
[EO-3203] Avoid accidentally pointing at master after a machine disconnects

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/NodeParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/NodeParameters.java
@@ -27,13 +27,13 @@ public class NodeParameters extends AbstractBuildParameters{
 
 	@Override
 	public Action getAction(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException, DontTriggerException {
-		Node node = build.getBuiltOn();
+		String nodeName = build.getBuiltOnStr();
 		Label nodeLabel;
 		// master does not return a node name so add it explicitly.
-		if(node == null) {
+		if(nodeName == null || nodeName == "") {
 			nodeLabel = Jenkins.getInstance().getSelfLabel();
 		} else {
-			nodeLabel = node.getSelfLabel();
+			nodeLabel = Label.get(nodeName);
 		}
 		listener.getLogger().println("Returning node parameter for " + nodeLabel.getDisplayName());
 		return new NodeAction(nodeLabel);


### PR DESCRIPTION
### SUMMARY
* This PR is a quick fix for an issue in the upstream plugin.
* Internal ticket: [EO-3203](https://jira.dp.hbo.com/browse/EO-3203)  hadron-auto-reboot-node-v1 is not working as intended
* Related JIRA ticket: [JENKINS-57472](https://issues.jenkins-ci.org/browse/JENKINS-57472)

### DETAILS
When the parameterized trigger plugin triggers a build, it asks for the "builtOn" node.  In the case of a machine disconnect, this is incorrect because it ends up asking Jenkins for the node with the appropriate name, which doesn't exist, so it returns `null`; but a node of `null` is also interpreted as "master" for legacy reasons.

The fix is to be explicit by asking for the node string itself.  If this is empty string or null, we know it's master; if it's not, we then ask for the canonical Label for the node string and return that (whether or not a machine with such a label is actually connected).

### TESTS
- No unit tests have been updated.
- Manual testing verified on `native-jenkins`.